### PR TITLE
Resolved bug that affected machines with non US Locales.

### DIFF
--- a/EnergyCheckUtils.java
+++ b/EnergyCheckUtils.java
@@ -1,3 +1,5 @@
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.lang.reflect.Field;
 public class EnergyCheckUtils {
 	public native static int scale(int freq);
@@ -46,9 +48,17 @@ public class EnergyCheckUtils {
 			double[] stats = new double[3];
 			String[] energy = EnergyInfo.split("#");
 
-			stats[0] = Double.parseDouble(energy[0]);
-			stats[1] = Double.parseDouble(energy[1]);
-			stats[2] = Double.parseDouble(energy[2]);
+			NumberFormat nf = NumberFormat.getInstance();
+			
+			try {
+				stats[0] = nf.parse(energy[0]).doubleValue();
+				stats[1] = nf.parse(energy[1]).doubleValue();
+				stats[2] = nf.parse(energy[2]).doubleValue();
+			} catch (ParseException e) {
+				stats[0] = 0.0;
+				stats[1] = 0.0;
+				stats[2] = 0.0;
+			}
 
 			return stats;
 


### PR DESCRIPTION
I was getting the following error, due to my machine being non US locale, so the values appeared with a comma instead of a dot:
```
0,000000#11913,476974#23490,014404
Exception in thread "main" java.lang.NumberFormatException: For input string: "0,000000"
	at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
	at sun.misc.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.lang.Double.parseDouble(Double.java:538)
	at EnergyCheckUtils.getEnergyStats(EnergyCheckUtils.java:49)
	at EnergyCheckUtils.main(EnergyCheckUtils.java:76)

```
The method `getEnergyStats` when calls `Double.parseDouble` fails because it expects the numbers to be formatted with a '.' instead of ','.
With the usage of `NumberFormat` it now uses the default System Locale, avoiding this problem.

Example output:
```
0,000000#13959,228394#27346,080170
0,000000#13966,696732#27378,764664
Power consumption of dram: 0.0 power consumption of cpu: 0.7468338000000585 power consumption of package: 3.268449399999736
```